### PR TITLE
Bug: put `percentage()` on wrong declaration

### DIFF
--- a/normalize/_document.scss
+++ b/normalize/_document.scss
@@ -14,8 +14,8 @@ $base-font-family: Times, serif !default;
  */
 
 html {
-  font-family: percentage($base-font-family / 16);
-  font-size: $base-font-size;
+  font-family: $base-font-family;
+  font-size: percentage($base-font-size / 16)$base-font-size;
   line-height: $base-line-height; /* 1 */
   -webkit-text-size-adjust: 100%; /* 2 */
 }

--- a/normalize/_document.scss
+++ b/normalize/_document.scss
@@ -15,7 +15,7 @@ $base-font-family: Times, serif !default;
 
 html {
   font-family: $base-font-family;
-  font-size: percentage($base-font-size / 16)$base-font-size;
+  font-size: percentage($base-font-size / 16);
   line-height: $base-line-height; /* 1 */
   -webkit-text-size-adjust: 100%; /* 2 */
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fizzion-normalize",
-  "version": "8.0.0-beta.2",
+  "version": "8.0.0-beta.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fizzion-normalize",
-  "version": "8.0.0-beta.2",
+  "version": "8.0.0-beta.3",
   "description": "Normalize.css as a node packaged module using scss",
   "main": "main.scss",
   "style": "main.scss",


### PR DESCRIPTION
Accidentally Put percentage on `font-family` rather than `font-size`.