### PR TITLE
Use SASS math.div

### DIFF
--- a/normalize/_document.scss
+++ b/normalize/_document.scss
@@ -3,6 +3,7 @@
 
    Document styling normalization.
    ========================================================================== */
+@use 'sass:math';
 
 $base-font-size: 16 !default;
 $base-line-height: 1.15 !default;
@@ -15,7 +16,7 @@ $base-font-family: Times, serif !default;
 
 html {
   font-family: $base-font-family;
-  font-size: percentage($base-font-size / 16);
+  font-size: percentage(math.div($base-font-size, 16));
   line-height: $base-line-height; /* 1 */
   -webkit-text-size-adjust: 100%; /* 2 */
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fizzion-normalize",
-  "version": "8.1.0",
+  "version": "8.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fizzion-normalize",
-  "version": "8.1.0",
+  "version": "8.1.1",
   "description": "Normalize.css as a node packaged module using scss",
   "main": "main.scss",
   "style": "main.scss",


### PR DESCRIPTION
`dart-sass` requires the use of `math.div` instead of the `/` operator. This replaces the single instance of division. 